### PR TITLE
Update thread-safe information in readme

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -99,7 +99,7 @@ be accepted without corresponding tests.
 == FEATURES/PROBLEMS:
 
 * This gem requires you to build and install an external C library
-* The QREncode lib this GEM is built around is NOT thread-safe!
+* The QREncode lib this GEM is built around is only thread-safe from version 3.2.0 onwards!
 
 == CONTRIBUTORS:
 


### PR DESCRIPTION
QREncode is thread-safe from version 3.2.0 onwards, 
< the version installed by most packet managers. 
(2011.11.26 - http://fukuchi.org/works/qrencode/index.html.en)
